### PR TITLE
Add shopname validation

### DIFF
--- a/app/scripts/add_scripttag.py
+++ b/app/scripts/add_scripttag.py
@@ -22,7 +22,9 @@ ssl._create_default_https_context = ssl._create_unverified_context
 slack_handler = SlackerLogHandler(settings.SLACK_API_KEY, 'production-logs', stack_trace=True)
 
 logger = logging.getLogger(__name__)
-logger.addHandler(slack_handler)
+
+if settings.DEVELOPMENT_MODE == 'PRODUCTION':
+    logger.addHandler(slack_handler)
 
 
 def authenticate(func):

--- a/app/shopifyutils.py
+++ b/app/shopifyutils.py
@@ -21,7 +21,9 @@ ssl._create_default_https_context = ssl._create_unverified_context
 slack_handler = SlackerLogHandler(settings.SLACK_API_KEY, 'production-logs', stack_trace=True)
 
 logger = logging.getLogger(__name__)
-logger.addHandler(slack_handler)
+
+if settings.DEVELOPMENT_MODE == 'PRODUCTION':
+    logger.addHandler(slack_handler)
 
 
 def get_stores():

--- a/app/test.py
+++ b/app/test.py
@@ -23,6 +23,29 @@ class AuthenticationTests(TestCase):
                                         'https://mystore.myshopify.com/admin/oauth/authorize'
                                         '?client_id=*&scope=*&redirect_uri=*'))
 
+    def test_invalid_shop_name_regex_auth_callback(self):
+        response1 = self.client.get(reverse('auth_callback'), {'hmac': '123',
+                                                              'locale': '123',
+                                                              'protocol': '123',
+                                                              'shop': 'does-not-end-in-my-shopify-dot-com',
+                                                              'timestamp': '123'})
+
+        response2 = self.client.get(reverse('auth_callback'), {'hmac': '123',
+                                                               'locale': '123',
+                                                               'protocol': '123',
+                                                               'shop': 'shop name with spaces',
+                                                               'timestamp': '123'})
+
+        response3 = self.client.get(reverse('auth_callback'), {'hmac': '123',
+                                                               'locale': '123',
+                                                               'protocol': '123',
+                                                               'shop': 'under_score_Special!#',
+                                                               'timestamp': '123'})
+
+        self.assertEqual(response1.status_code, 400)
+        self.assertEqual(response2.status_code, 400)
+        self.assertEqual(response3.status_code, 400)
+
 
 class DevelopmentToProductionDeploymentTest(TestCase):
     """

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,7 +8,9 @@ from slacker_log_handler import SlackerLogHandler
 slack_handler = SlackerLogHandler(settings.SLACK_API_KEY, 'production-logs', stack_trace=True)
 
 logger = logging.getLogger(__name__)
-logger.addHandler(slack_handler)
+
+if settings.DEVELOPMENT_MODE == 'PRODUCTION':
+    logger.addHandler(slack_handler)
 
 def authenticate(request):
     """


### PR DESCRIPTION
Per https://github.com/Shopify/shopify_python_api:

Ensure the provided hostname parameter is a valid hostname, ends with myshopify.com, and does not contain characters other than letters (a-z), numbers (0-9), dots, and hyphens.

Also only allow slack notifications if `DEVELOPMENT_MODE` is `PRODUCTION`.